### PR TITLE
Ensuring UIKit GestureRecognizer APIs gets dispatched on main scheduler

### DIFF
--- a/Sources/Controls/UIGestureRecognizer+Combine.swift
+++ b/Sources/Controls/UIGestureRecognizer+Combine.swift
@@ -72,6 +72,7 @@ private func gesturePublisher<Gesture: UIGestureRecognizer>(for gesture: Gesture
                              removeTargetAction: { gesture, target, action in
                                 gesture?.removeTarget(target, action: action)
                              })
+              .subscribe(on: DispatchQueue.main)
               .map { gesture }
               .eraseToAnyPublisher()
 }


### PR DESCRIPTION
I introduced `schedule(on:)` to make sure we dispatch UIKit's GestureRecognizer API on main thread.