### PR TITLE
Animated assign subscriber

### DIFF
--- a/Sources/AnimatedAssignSubscriber.swift
+++ b/Sources/AnimatedAssignSubscriber.swift
@@ -27,29 +27,27 @@ public enum AssignTransition {
 }
 
 extension Publisher where Self.Failure == Never {
-    
-    /// Behaves identically to `Publisher.assign(to:on:)` except that it allows the user to
-    /// "wrap" emitting output in an animation transition.
-    ///
-    /// For example if you assign values to a
-    /// `UILabel` on screen you can make it flip over when each new value is set:
-    /// ```
-    /// myPublisher
-    ///   .assign(to: \.text, on: myLabel, animation: .flip(direction: .bottom, duration: 0.33))
-    /// ```
-    /// Or you can make an image view crossfade any new images it displays:
-    /// ```
-    /// myImagePublisher
-    ///   .assign(to: \.image, on: myImageView, animation: .fade(duration: 0.5))
-    /// ```
-    /// Finally you can set any custom animation including choice side effects as so. For example
-    /// this is how you can move the label each time you set a new value via `assign(to:on:animation:)`:
-    /// ```
-    /// myPublisher
-    ///   .assign(to: \.text, on: myLabel, animation: .animation(duration: 0.33, options: .curveEaseIn, animations: { _ in
-    ///     myLabel.center.x += 10.0
-    ///   }, completion: nil))
-    /// ```
+	/// Behaves identically to `Publisher.assign(to:on:)` except that it allows the user to
+	/// "wrap" emitting output in an animation transition.
+	///
+	/// For example if you assign values to a `UILabel` on screen you
+	/// can make it flip over when each new value is set:
+	///
+	/// ```
+	/// myPublisher
+	///   .assign(to: \.text,
+	///             on: myLabel,
+	///             animation: .flip(direction: .bottom, duration: 0.33))
+	/// ```
+	///
+	/// You may also provide a custom animation block, as follows:
+	///
+	/// ```
+	/// myPublisher
+	///   .assign(to: \.text, on: myLabel, animation: .animation(duration: 0.33, options: .curveEaseIn, animations: { _ in
+	///     myLabel.center.x += 10.0
+	///   }, completion: nil))
+	/// ```
     public func assign<Root>(to keyPath: ReferenceWritableKeyPath<Root, Self.Output>, on object: Root, animation: AssignTransition) -> AnyCancellable {
         guard let view = object as? UIView else {
             return assign(to: keyPath, on: object)

--- a/Sources/AnimatedAssignSubscriber.swift
+++ b/Sources/AnimatedAssignSubscriber.swift
@@ -1,0 +1,93 @@
+//
+//  AnimatedAssignSubscriber.swift
+//
+//  Created by Marin Todorov on 5/3/20.
+//
+
+import Foundation
+import Combine
+
+#if canImport(UIKit)
+import UIKit
+
+/// A list of animations that can be used with `Publisher.assign(to:on:animation:)`
+public enum AssignTransition {
+    public enum Direction {
+        case top, bottom, left, right
+    }
+    
+    /// Flip from either bottom, top, left, or right.
+    case flip(direction: Direction, duration: TimeInterval)
+    
+    /// Cross fade with previous value.
+    case fade(duration: TimeInterval)
+    
+    /// A custom animation. Do not include your own code to update the target of the assign subscriber.
+    case animation(duration: TimeInterval, options: UIView.AnimationOptions, animations: () -> Void, completion: ((Bool) -> Void)?)
+}
+
+extension Publisher where Self.Failure == Never {
+    
+    /// Behaves identically to `Publisher.assign(to:on:)` except that it allows the user to
+    /// "wrap" emitting output in an animation transition.
+    ///
+    /// For example if you assign values to a
+    /// `UILabel` on screen you can make it flip over when each new value is set:
+    /// ```
+    /// myPublisher
+    ///   .assign(to: \.text, on: myLabel, animation: .flip(direction: .bottom, duration: 0.33))
+    /// ```
+    /// Or you can make an image view crossfade any new images it displays:
+    /// ```
+    /// myImagePublisher
+    ///   .assign(to: \.image, on: myImageView, animation: .fade(duration: 0.5))
+    /// ```
+    /// Finally you can set any custom animation including choice side effects as so. For example
+    /// this is how you can move the label each time you set a new value via `assign(to:on:animation:)`:
+    /// ```
+    /// myPublisher
+    ///   .assign(to: \.text, on: myLabel, animation: .animation(duration: 0.33, options: .curveEaseIn, animations: { _ in
+    ///     myLabel.center.x += 10.0
+    ///   }, completion: nil))
+    /// ```
+    public func assign<Root>(to keyPath: ReferenceWritableKeyPath<Root, Self.Output>, on object: Root, animation: AssignTransition) -> AnyCancellable {
+        guard let view = object as? UIView else {
+            return assign(to: keyPath, on: object)
+        }
+
+        var transition: UIView.AnimationOptions
+        var duration: TimeInterval
+        
+        switch animation {
+        case .fade(let interval):
+            duration = interval
+            transition = .transitionCrossDissolve
+        case .flip(let dir, let interval):
+            duration = interval
+            switch dir {
+            case .bottom: transition = .transitionFlipFromBottom
+            case .top: transition    = .transitionFlipFromTop
+            case .left: transition   = .transitionFlipFromLeft
+            case .right: transition  = .transitionFlipFromRight
+            }
+        case .animation(let interval, let options, let animations, let completion):
+            return self
+                .handleEvents(receiveOutput: { value in
+                    UIView.animate(withDuration: interval, delay: 0, options: options, animations: {
+                        object[keyPath: keyPath] = value
+                        animations()
+                    }, completion: completion)
+                })
+                .assign(to: keyPath, on: object)
+        }
+
+        return self
+            .handleEvents(receiveOutput: { value in
+                UIView.transition(with: view, duration: duration, options: transition, animations: {
+                    object[keyPath: keyPath] = value
+                }, completion: nil)
+            })
+            .assign(to: keyPath, on: object)
+    }
+}
+#endif

--- a/Sources/AnimatedAssignSubscriber.swift
+++ b/Sources/AnimatedAssignSubscriber.swift
@@ -27,27 +27,27 @@ public enum AssignTransition {
 }
 
 extension Publisher where Self.Failure == Never {
-	/// Behaves identically to `Publisher.assign(to:on:)` except that it allows the user to
-	/// "wrap" emitting output in an animation transition.
-	///
-	/// For example if you assign values to a `UILabel` on screen you
-	/// can make it flip over when each new value is set:
-	///
-	/// ```
-	/// myPublisher
-	///   .assign(to: \.text,
-	///             on: myLabel,
-	///             animation: .flip(direction: .bottom, duration: 0.33))
-	/// ```
-	///
-	/// You may also provide a custom animation block, as follows:
-	///
-	/// ```
-	/// myPublisher
-	///   .assign(to: \.text, on: myLabel, animation: .animation(duration: 0.33, options: .curveEaseIn, animations: { _ in
-	///     myLabel.center.x += 10.0
-	///   }, completion: nil))
-	/// ```
+    /// Behaves identically to `Publisher.assign(to:on:)` except that it allows the user to
+    /// "wrap" emitting output in an animation transition.
+    ///
+    /// For example if you assign values to a `UILabel` on screen you
+    /// can make it flip over when each new value is set:
+    ///
+    /// ```
+    /// myPublisher
+    ///   .assign(to: \.text,
+    ///             on: myLabel,
+    ///             animation: .flip(direction: .bottom, duration: 0.33))
+    /// ```
+    ///
+    /// You may also provide a custom animation block, as follows:
+    ///
+    /// ```
+    /// myPublisher
+    ///   .assign(to: \.text, on: myLabel, animation: .animation(duration: 0.33, options: .curveEaseIn, animations: { _ in
+    ///     myLabel.center.x += 10.0
+    ///   }, completion: nil))
+    /// ```
     public func assign<Root: UIView>(to keyPath: ReferenceWritableKeyPath<Root, Self.Output>, on object: Root, animation: AssignTransition) -> AnyCancellable {
         var transition: UIView.AnimationOptions
         var duration: TimeInterval
@@ -68,29 +68,29 @@ extension Publisher where Self.Failure == Never {
             // Use a custom animation.
             return handleEvents(receiveOutput: { value in
                     UIView.animate(withDuration: interval,
-                    				 delay: 0,
-                    				 options: options,
-                    				 animations: {
-				                       object[keyPath: keyPath] = value
-                				       animations()
-				                     },
-				                     completion: completion)
+                                     delay: 0,
+                                     options: options,
+                                     animations: {
+                                       object[keyPath: keyPath] = value
+                                       animations()
+                                     },
+                                     completion: completion)
                 })
-                .assign(to: keyPath, on: object)
+                .sink { _ in }
         }
 
         // Use one of the built-in transitions like flip or crossfade.
         return self
             .handleEvents(receiveOutput: { value in
                 UIView.transition(with: object,
-				                    duration: duration,
-				                    options: transition,
-				                    animations: {
-				 	                   object[keyPath: keyPath] = value
-					                },
-					                completion: nil)
+                                    duration: duration,
+                                    options: transition,
+                                    animations: {
+                                        object[keyPath: keyPath] = value
+                                    },
+                                    completion: nil)
             })
-            .assign(to: keyPath, on: object)
+            .sink { _ in }
     }
 }
 #endif

--- a/Sources/AnimatedAssignSubscriber.swift
+++ b/Sources/AnimatedAssignSubscriber.swift
@@ -48,7 +48,7 @@ extension Publisher where Self.Failure == Never {
 	///     myLabel.center.x += 10.0
 	///   }, completion: nil))
 	/// ```
-    public func assign<Root>(to keyPath: ReferenceWritableKeyPath<Root, Self.Output>, on object: Root, animation: AssignTransition) -> AnyCancellable {
+    public func assign<Root: UIView>(to keyPath: ReferenceWritableKeyPath<Root, Self.Output>, on object: Root, animation: AssignTransition) -> AnyCancellable {
         guard let view = object as? UIView else {
             return assign(to: keyPath, on: object)
         }

--- a/Sources/AnimatedAssignSubscriber.swift
+++ b/Sources/AnimatedAssignSubscriber.swift
@@ -60,7 +60,7 @@ extension Publisher where Self.Failure == Never {
         case .fade(let interval):
             duration = interval
             transition = .transitionCrossDissolve
-        case .flip(let dir, let interval):
+        case let .flip(dir, interval):
             duration = interval
             switch dir {
             case .bottom: transition = .transitionFlipFromBottom

--- a/Sources/AnimatedAssignSubscriber.swift
+++ b/Sources/AnimatedAssignSubscriber.swift
@@ -84,9 +84,13 @@ extension Publisher where Self.Failure == Never {
 
         return self
             .handleEvents(receiveOutput: { value in
-                UIView.transition(with: view, duration: duration, options: transition, animations: {
-                    object[keyPath: keyPath] = value
-                }, completion: nil)
+                UIView.transition(with: view,
+				                    duration: duration,
+				                    options: transition,
+				                    animations: {
+				 	                   object[keyPath: keyPath] = value
+					                },
+					                completion: nil)
             })
             .assign(to: keyPath, on: object)
     }

--- a/Sources/AnimatedAssignSubscriber.swift
+++ b/Sources/AnimatedAssignSubscriber.swift
@@ -49,10 +49,6 @@ extension Publisher where Self.Failure == Never {
 	///   }, completion: nil))
 	/// ```
     public func assign<Root: UIView>(to keyPath: ReferenceWritableKeyPath<Root, Self.Output>, on object: Root, animation: AssignTransition) -> AnyCancellable {
-        guard let view = object as? UIView else {
-            return assign(to: keyPath, on: object)
-        }
-
         var transition: UIView.AnimationOptions
         var duration: TimeInterval
         
@@ -69,6 +65,7 @@ extension Publisher where Self.Failure == Never {
             case .right: transition  = .transitionFlipFromRight
             }
         case let .animation(interval, options, animations, completion):
+            // Use a custom animation.
             return handleEvents(receiveOutput: { value in
                     UIView.animate(withDuration: interval,
                     				 delay: 0,
@@ -82,9 +79,10 @@ extension Publisher where Self.Failure == Never {
                 .assign(to: keyPath, on: object)
         }
 
+        // Use one of the built-in transitions like flip or crossfade.
         return self
             .handleEvents(receiveOutput: { value in
-                UIView.transition(with: view,
+                UIView.transition(with: object,
 				                    duration: duration,
 				                    options: transition,
 				                    animations: {

--- a/Sources/AnimatedAssignSubscriber.swift
+++ b/Sources/AnimatedAssignSubscriber.swift
@@ -68,13 +68,16 @@ extension Publisher where Self.Failure == Never {
             case .left: transition   = .transitionFlipFromLeft
             case .right: transition  = .transitionFlipFromRight
             }
-        case .animation(let interval, let options, let animations, let completion):
-            return self
-                .handleEvents(receiveOutput: { value in
-                    UIView.animate(withDuration: interval, delay: 0, options: options, animations: {
-                        object[keyPath: keyPath] = value
-                        animations()
-                    }, completion: completion)
+        case let .animation(interval, options, animations, completion):
+            return handleEvents(receiveOutput: { value in
+                    UIView.animate(withDuration: interval,
+                    				 delay: 0,
+                    				 options: options,
+                    				 animations: {
+				                       object[keyPath: keyPath] = value
+                				       animations()
+				                     },
+				                     completion: completion)
                 })
                 .assign(to: keyPath, on: object)
         }


### PR DESCRIPTION
This PR adds a variation of `assign(to:on:)` with an extra parameter allowing the user to set an animation transition to play when emitting output values.

E.g. if you have:

```
let counts = ["One", "Two", "Three", "Four", "Five"]

Timer.publish(every: 1, on: RunLoop.main, in: .common)
    .autoconnect()
    .scan(0) { (result, _) -> Int in
        return result + 1 >= counts.count ? 0 : result + 1
    }
    .map { counts[$0] }
    .assign(to: \UILabel.text, on: label, animation: .flip(direction: .left, duration: 0.25))
    .store(in: &subscriptions)
```

It makes the updates to the label animated like so:

![countdown](https://user-images.githubusercontent.com/633862/80922526-11aa7180-8d7e-11ea-84b8-efbcae4107ca.gif)
