### PR TITLE
Fix UIPageControl currentPagePublisher only emit once bug

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0AEC3D4E25260DC7007EE97C /* UISearchBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEC3D4D25260DC7007EE97C /* UISearchBarTests.swift */; };
 		3D5D919445BB2B0DA0F0A455 /* Pods_Example_ExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE798B0656978A899BDE50BF /* Pods_Example_ExampleTests.framework */; };
+		3F50DED325D6B4B700AC53A7 /* UIPageControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F50DED225D6B4B700AC53A7 /* UIPageControlTests.swift */; };
 		499340808F6A4BFA9D08AB34 /* Pods_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7789E43DCE40382369F72B2 /* Pods_Example.framework */; };
 		7822AD1E24E1504600187502 /* UITextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7822AD1D24E1504600187502 /* UITextViewTests.swift */; };
 		A233795622F59DBD0083F92F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A233795522F59DBD0083F92F /* Main.storyboard */; };
@@ -33,6 +34,7 @@
 
 /* Begin PBXFileReference section */
 		0AEC3D4D25260DC7007EE97C /* UISearchBarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISearchBarTests.swift; sourceTree = "<group>"; };
+		3F50DED225D6B4B700AC53A7 /* UIPageControlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPageControlTests.swift; sourceTree = "<group>"; };
 		7822AD1D24E1504600187502 /* UITextViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITextViewTests.swift; sourceTree = "<group>"; };
 		A233795522F59DBD0083F92F /* Main.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		A24C43F922F592E700BC2E2B /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -138,6 +140,7 @@
 				DC8A555D24B60A9A007BCEEC /* UICollectionViewTests.swift */,
 				7822AD1D24E1504600187502 /* UITextViewTests.swift */,
 				0AEC3D4D25260DC7007EE97C /* UISearchBarTests.swift */,
+				3F50DED225D6B4B700AC53A7 /* UIPageControlTests.swift */,
 				DC8A555724B5ED4B007BCEEC /* Info.plist */,
 			);
 			path = ExampleTests;
@@ -343,6 +346,7 @@
 				7822AD1E24E1504600187502 /* UITextViewTests.swift in Sources */,
 				0AEC3D4E25260DC7007EE97C /* UISearchBarTests.swift in Sources */,
 				DC8A555E24B60A9A007BCEEC /* UICollectionViewTests.swift in Sources */,
+				3F50DED325D6B4B700AC53A7 /* UIPageControlTests.swift in Sources */,
 				DC8A555624B5ED4B007BCEEC /* UITableViewTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/ExampleTests/UIPageControlTests.swift
+++ b/Example/ExampleTests/UIPageControlTests.swift
@@ -1,0 +1,34 @@
+//
+//  UIPageControlTests.swift
+//  ExampleTests
+//
+//  Created by Lu Hao on 2021/2/12.
+//  Copyright © 2021 Shai Mishali. All rights reserved.
+//
+
+import XCTest
+import Combine
+@testable import CombineCocoa
+
+class UIPageControlTests: XCTestCase {
+
+    func test_pageControl() {
+
+        let maxPageCount = 10
+
+        let pc = UIPageControl()
+        pc.numberOfPages = maxPageCount
+
+        var values = [Int]()
+
+        let sub = pc.currentPagePublisher.sink { values.append($0) }
+
+        for page in 1..<maxPageCount {
+            pc.currentPage = page
+        }
+
+        XCTAssertEqual(values, Array(0..<maxPageCount))
+
+        sub.cancel()
+    }
+}

--- a/Sources/CombineCocoa/Controls/UIPageControl+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UIPageControl+Combine.swift
@@ -14,8 +14,7 @@ import UIKit
 public extension UIPageControl {
     /// A publisher emitting current page changes for this page control.
     var currentPagePublisher: AnyPublisher<Int, Never> {
-        Publishers.ControlProperty(control: self, events: .defaultValueEvents, keyPath: \.currentPage)
-                  .eraseToAnyPublisher()
+        publisher(for: \.currentPage).eraseToAnyPublisher()
     }
 }
 #endif


### PR DESCRIPTION
I've fixed the bug in #35 

The `UIControl.Event` won't be triggered by the change of `currentPage` in `UIPageControl`.

So, I just use the publisher for KVO, and it works.