### PR TITLE
fix: build failure

### DIFF
--- a/Sources/CombineCocoa/CombineControlEvent.swift
+++ b/Sources/CombineCocoa/CombineControlEvent.swift
@@ -9,7 +9,7 @@
 #if canImport(Combine)
 import Combine
 import Foundation
-import UIKit.UIControl
+import UIKit
 
 // MARK: - Publisher
 @available(iOS 13.0, *)


### PR DESCRIPTION
For some reason it can be built separately, but building it as a dependency fails
<img width="899" alt="Screenshot 2021-06-22 at 00 33 55" src="https://user-images.githubusercontent.com/40476363/122830807-88dbf580-d2f1-11eb-8d20-4587e28674f5.png">

Also, I don't want to be toxic, but I'd like to mention that this indentation
```swift
public init(
    control: Control,
    events: Control.Event
) {
    self.control = control
    self.controlEvents = events
}
```
looks more native to Combine, SwiftUI and Swift in general than this
```swift
public init(control: Control,
            events: Control.Event) {
    self.control = control
    self.controlEvents = events
}
```
which is more like objc indentation, and it makes me sad 🥲 maybe you should update your styleguides 😅