### PR TITLE
Increase deployment target to iOS11

### DIFF
--- a/CombineCocoa.podspec
+++ b/CombineCocoa.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   
     s.requires_arc     = true
   
-    s.ios.deployment_target     = '10.0'
+    s.ios.deployment_target     = '11.0'
   
     s.source_files = 'Sources/**/*.{swift,h,m}'
     s.frameworks   = ['Combine', 'Foundation']

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "CombineCocoa",
-    platforms: [.iOS(.v10)],
+    platforms: [.iOS(.v11)],
     products: [
         .library(name: "CombineCocoa", targets: ["CombineCocoa"]),
     ],


### PR DESCRIPTION
Fixes #56 

As indicated in the Xcode 13 release note (https://developer.apple.com/documentation/xcode-release-notes/xcode-13-release-notes)

> Known Issues
> <br>Swift libraries depending on Combine may fail to build for targets including armv7 and i386 architectures. (82183186, 82189214)
Workaround: Use an updated version of the library that isn’t impacted (if available) or remove armv7 and i386 support (for example, increase the deployment target of the library to iOS 11 or higher).

So I increased deployment target to iOS11 in CocoaPod and SPM. 
While this is not optimal, it is at least a functioning workaround for now. 🤔 