### PR TITLE
Work around canImport(Combine) being broken in Xcode 13

### DIFF
--- a/Sources/CombineCocoa/AnimatedAssignSubscriber.swift
+++ b/Sources/CombineCocoa/AnimatedAssignSubscriber.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-#if canImport(UIKit) && canImport(Combine)
+#if canImport(UIKit) && !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 import UIKit
 

--- a/Sources/CombineCocoa/CombineControlEvent.swift
+++ b/Sources/CombineCocoa/CombineControlEvent.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 import Foundation
 import UIKit.UIControl

--- a/Sources/CombineCocoa/CombineControlProperty.swift
+++ b/Sources/CombineCocoa/CombineControlProperty.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 import Foundation
 import UIKit.UIControl

--- a/Sources/CombineCocoa/CombineControlTarget.swift
+++ b/Sources/CombineCocoa/CombineControlTarget.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 import Foundation
 

--- a/Sources/CombineCocoa/Controls/NSTextStorage+Combine.swift
+++ b/Sources/CombineCocoa/Controls/NSTextStorage+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import UIKit
 import Combine
 

--- a/Sources/CombineCocoa/Controls/UIBarButtonItem+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UIBarButtonItem+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 import UIKit
 

--- a/Sources/CombineCocoa/Controls/UIButton+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UIButton+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 import UIKit
 

--- a/Sources/CombineCocoa/Controls/UICollectionView+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UICollectionView+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(UIKit) && canImport(Combine)
+#if canImport(UIKit) && !(os(iOS) && (arch(i386) || arch(arm)))
 import Foundation
 import UIKit
 import Combine

--- a/Sources/CombineCocoa/Controls/UIControl+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UIControl+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 import UIKit
 

--- a/Sources/CombineCocoa/Controls/UIDatePicker+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UIDatePicker+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 import UIKit
 

--- a/Sources/CombineCocoa/Controls/UIGestureRecognizer+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UIGestureRecognizer+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 import UIKit
 

--- a/Sources/CombineCocoa/Controls/UIPageControl+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UIPageControl+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 import UIKit
 

--- a/Sources/CombineCocoa/Controls/UIRefreshControl+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UIRefreshControl+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 import UIKit
 

--- a/Sources/CombineCocoa/Controls/UIScrollView+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UIScrollView+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import UIKit
 import Combine
 

--- a/Sources/CombineCocoa/Controls/UISearchBar+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UISearchBar+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import UIKit
 import Combine
 

--- a/Sources/CombineCocoa/Controls/UISegmentedControl+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UISegmentedControl+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 import UIKit
 

--- a/Sources/CombineCocoa/Controls/UISlider+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UISlider+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 import UIKit
 

--- a/Sources/CombineCocoa/Controls/UIStepper+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UIStepper+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 import UIKit
 

--- a/Sources/CombineCocoa/Controls/UISwitch+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UISwitch+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 import UIKit
 

--- a/Sources/CombineCocoa/Controls/UITableView+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UITableView+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(UIKit) && canImport(Combine)
+#if canImport(UIKit) && !(os(iOS) && (arch(i386) || arch(arm)))
 import Foundation
 import UIKit
 import Combine

--- a/Sources/CombineCocoa/Controls/UITextField+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UITextField+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 import UIKit
 

--- a/Sources/CombineCocoa/Controls/UITextView+Combine.swift
+++ b/Sources/CombineCocoa/Controls/UITextView+Combine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import UIKit
 import Combine
 

--- a/Sources/CombineCocoa/DelegateProxy/DelegateProxy.swift
+++ b/Sources/CombineCocoa/DelegateProxy/DelegateProxy.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Foundation
 import Combine
 

--- a/Sources/CombineCocoa/DelegateProxy/DelegateProxyPublisher.swift
+++ b/Sources/CombineCocoa/DelegateProxy/DelegateProxyPublisher.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Foundation
 import Combine
 

--- a/Sources/CombineCocoa/DelegateProxy/DelegateProxyType.swift
+++ b/Sources/CombineCocoa/DelegateProxy/DelegateProxyType.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Combine Community. All rights reserved.
 //
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Foundation
 
 private var associatedKey = "delegateProxy"


### PR DESCRIPTION
Fixes: https://github.com/CombineCommunity/CombineCocoa/issues/56

Applying the same fix as used by the Realm project. Its not pretty but it does the job to maintain compatibility with iOS 10

> Xcode 13 beta 3 added a swiftinterface file for armv7 Combine which makes canImport(Combine) return true, but the swiftinterface file doesn't actually compile (and no armv7 devices can run OS versions with Combine). Work around this by replacing the canImport(Combine) checks with a define we manually set when building for armv7.

realm/realm-cocoa#7401